### PR TITLE
fix(battery_plus): Fix battery level retrieval to handle empty power sources array

### DIFF
--- a/packages/battery_plus/battery_plus/macos/Classes/BatteryPlusMacosPlugin.swift
+++ b/packages/battery_plus/battery_plus/macos/Classes/BatteryPlusMacosPlugin.swift
@@ -48,6 +48,9 @@ public class BatteryPlusMacosPlugin: NSObject, FlutterPlugin {
     private func getBatteryLevel()-> Int {
         let powerSourceSnapshot = IOPSCopyPowerSourcesInfo().takeRetainedValue()
         let sources = IOPSCopyPowerSourcesList(powerSourceSnapshot).takeRetainedValue() as Array
+        if sources.isEmpty {
+            return -1
+        }
         let description = IOPSGetPowerSourceDescription(powerSourceSnapshot, sources[0]).takeUnretainedValue() as! [String: AnyObject]
         if let currentCapacity = description[kIOPSCurrentCapacityKey] as? Int {
             return currentCapacity;


### PR DESCRIPTION
## Description

When using a desktop Mac, such as a Mac mini, retrieving the battery level can cause a crash due to an array out-of-bounds error. I added a check to return -1 when the power sources list is empty.

## Related Issues


## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

